### PR TITLE
Remove Period Stripping from Yahoo domain

### DIFF
--- a/email_normalize/providers.py
+++ b/email_normalize/providers.py
@@ -55,7 +55,7 @@ class Rackspace(MailboxProvider):
 
 
 class Yahoo(MailboxProvider):
-    Flags: Rules = Rules.DASH_ADDRESSING ^ Rules.STRIP_PERIODS
+    Flags: Rules = Rules.DASH_ADDRESSING
     MXDomains: typing.Set[str] = {'yahoodns.net'}
 
 


### PR DESCRIPTION
As far as I can tell Yahoo does not strip periods from email addresses.

https://github.com/dimuska139/go-email-normalizer/issues/5 
https://stackoverflow.com/a/36125463/4941009

I also signed up for a Yahoo email address and found I would get a bounce back email when I included extra dots in the address.