### PR TITLE
Fix CI tests; drop 3.7; add 3.12, 3.14

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: ['3.8', '3.9']
     container:
       image: python:${{ matrix.python }}-alpine
     steps:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        python: ['3.8', '3.9']
+        python: ['3.8', '3.9', '3.12', '3.14']
     container:
       image: python:${{ matrix.python }}-alpine
     steps:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.12', '3.14']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     container:
       image: python:${{ matrix.python }}-alpine
     steps:

--- a/email_normalize/__init__.py
+++ b/email_normalize/__init__.py
@@ -215,7 +215,7 @@ class Normalizer:
     def _lookup_provider(mx_records: typing.List[typing.Tuple[int, str]]) \
             -> typing.Optional[providers.MailboxProvider]:
         for priority, host in mx_records:
-            lchost = host.lower();
+            lchost = host.lower()
             for provider in providers.Providers:
                 for domain in provider.MXDomains:
                     if lchost.endswith(domain):

--- a/email_normalize/__init__.py
+++ b/email_normalize/__init__.py
@@ -253,6 +253,6 @@ def normalize(email_address: str) -> Result:
     :param email_address: The address to normalize
 
     """
-    loop = asyncio.get_event_loop()
-    normalizer = Normalizer()
-    return loop.run_until_complete(normalizer.normalize(email_address))
+    async def _normalize():
+        return await Normalizer().normalize(email_address)
+    return asyncio.run(_normalize())

--- a/email_normalize/__init__.py
+++ b/email_normalize/__init__.py
@@ -154,8 +154,8 @@ class Normalizer:
                 mx_records, ttl = [], self.failure_ttl
             else:
                 mx_records = [(r.priority, r.host) for r in records]
-                ttl = min(r.ttl for r in records) \
-                    if records else self.failure_ttl
+                ttl = min((r.ttl for r in records if r.ttl >= 0),
+                          default=self.failure_ttl)
 
             # Prune the cache if over the limit, finding least used, oldest
             if len(cache.keys()) >= self.cache_limit:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Communications

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ zip_safe = true
 
 [options.extras_require]
 testing =
-    asynctest
     coverage
     flake8
     flake8-comprehensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,11 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Communications
     Topic :: Communications :: Email
     Topic :: Internet

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -2,8 +2,7 @@ import typing
 import unittest
 import uuid
 import warnings
-
-from asynctest import mock
+from unittest import mock
 
 import email_normalize
 

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,78 +1,34 @@
 import asyncio
-import functools
-import logging
 import operator
-import os
 import time
 import unittest
 import uuid
+from unittest import mock
 
 import aiodns
-from asynctest import mock
 
 import email_normalize
 
-LOGGER = logging.getLogger(__name__)
 
-
-def async_test(*func):
-    if func:
-        @functools.wraps(func[0])
-        def wrapper(*args, **kwargs):
-            LOGGER.debug('Starting test with loop %r', args[0])
-            args[0].loop.run_until_complete(func[0](*args, **kwargs))
-            LOGGER.debug('Test completed')
-        return wrapper
-
-
-class AsyncTestCase(unittest.TestCase):
+class NormalizerTestCase(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self) -> None:
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self.loop)
-        self.loop.set_debug(True)
-        self.timeout = int(os.environ.get('ASYNC_TIMEOUT', '5'))
-        self.timeout_handle = self.loop.call_later(
-            self.timeout, self.on_timeout)
-        self.resolver = aiodns.DNSResolver(loop=self.loop)
         self.normalizer = email_normalize.Normalizer()
-        self.normalizer._resolver = self.resolver
-        email_normalize.cache = {}
+        email_normalize.cache.clear()
 
     def tearDown(self):
-        LOGGER.debug('In AsyncTestCase.tearDown')
-        if not self.timeout_handle.cancelled():
-            self.timeout_handle.cancel()
-        self.loop.run_until_complete(self.loop.shutdown_asyncgens())
-        if self.loop.is_running:
-            self.loop.close()
-        super().tearDown()
+        email_normalize.cache.clear()
 
-    def on_timeout(self):
-        self.loop.stop()
-        raise TimeoutError(
-            'Test duration exceeded {} seconds'.format(self.timeout))
-
-
-class NormalizerTestCase(AsyncTestCase):
-
-    def setUp(self) -> None:
-        super().setUp()
-        if 'gmail.com' in email_normalize.cache:
-            del email_normalize.cache['gmail.com']
-
-    @async_test
     async def test_mx_records(self):
-        result = await self.resolver.query('gmail.com', 'MX')
-        expectation = []
-        for record in result:
-            expectation.append((record.priority, record.host))
-        expectation.sort(key=operator.itemgetter(0, 1))
+        resolver = aiodns.DNSResolver()
+        result = await resolver.query('gmail.com', 'MX')
+        expectation = sorted(
+            [(r.priority, r.host) for r in result],
+            key=operator.itemgetter(0, 1))
         self.assertListEqual(
             await self.normalizer.mx_records('gmail.com'),
             expectation)
 
-    @async_test
     async def test_cache(self):
         await self.normalizer.mx_records('gmail.com')
         await self.normalizer.mx_records('gmail.com')
@@ -82,7 +38,6 @@ class NormalizerTestCase(AsyncTestCase):
         with self.assertRaises(KeyError):
             self.assertIsNone(email_normalize.cache['foo'])
 
-    @async_test
     async def test_cache_max_size(self):
         for offset in range(0, self.normalizer.cache_limit):
             key = 'key-{}'.format(offset)
@@ -100,7 +55,6 @@ class NormalizerTestCase(AsyncTestCase):
         self.assertNotIn(key1, email_normalize.cache)
         self.assertIn(key2, email_normalize.cache)
 
-    @async_test
     async def test_cache_expiration(self):
         await self.normalizer.mx_records('gmail.com')
         cached_at = email_normalize.cache['gmail.com'].cached_at
@@ -111,7 +65,6 @@ class NormalizerTestCase(AsyncTestCase):
         self.assertGreater(
             email_normalize.cache['gmail.com'].cached_at, cached_at)
 
-    @async_test
     async def test_empty_mx_list(self):
         with mock.patch.object(self.normalizer, 'mx_records') as mx_records:
             mx_records.return_value = []
@@ -120,22 +73,18 @@ class NormalizerTestCase(AsyncTestCase):
             self.assertIsNone(result.mailbox_provider)
             self.assertListEqual(result.mx_records, [])
 
-    @async_test
     async def test_failure_cached(self):
         key = str(uuid.uuid4())
         records = await self.normalizer.mx_records(key)
         self.assertListEqual(records, [])
         self.assertIn(key, email_normalize.cache.keys())
 
-    @async_test
     async def test_failure_not_cached(self):
-        email_normalize.cache_failures = False
+        self.normalizer.cache_failures = False
         key = str(uuid.uuid4())
         records = await self.normalizer.mx_records(key)
         self.assertListEqual(records, [])
-        email_normalize.cache_failures = True
 
-    @async_test
     async def test_weird_mx_list(self):
         with mock.patch.object(self.normalizer, 'mx_records') as recs:
             recs.return_value = [


### PR DESCRIPTION
- Fix compatibility with newer pycares
- Dropped 3.7 due to flake8 incompatibility and asynctest not working with 3.14. I _could_ try to work around that, but I figure 3.7 has been out of support since 2023 that it's not worth it.
- Replaced asynctest with native async unittest (asynctest doesn't work with 3.14)
- Added support through 3.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MX TTL handling improved to ignore invalid TTLs and use a safe fallback.

* **Chores**
  * Updated supported Python classifiers (removed 3.7; added 3.10–3.14).
  * Expanded CI testing matrix to include newer Python versions.
  * Made normalization entrypoint robust against existing event loop usage.

* **Tests**
  * Modernized test suite to use native unittest async support and standard mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->