### PR TITLE
Remove Yahoo dash address normalization

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,5 +1,11 @@
 name: Testing
 on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'setup.*'
+      - '*.md'
+      - '*.rst'
   push:
     branches: ["*"]
     paths-ignore:

--- a/email_normalize/__init__.py
+++ b/email_normalize/__init__.py
@@ -197,8 +197,6 @@ class Normalizer:
                 local_part = local_part.replace('.', '')
             if provider.Flags & providers.Rules.PLUS_ADDRESSING:
                 local_part = local_part.split('+')[0]
-            if provider.Flags & providers.Rules.DASH_ADDRESSING:
-                local_part = local_part.split('-')[0]
         return Result(email_address, '@'.join([local_part, domain_part]),
                       mx_records, provider.__name__ if provider else None)
 

--- a/email_normalize/providers.py
+++ b/email_normalize/providers.py
@@ -12,7 +12,7 @@ class Rules(enum.Flag):
     Used to determine how to normalize provider specific email addresses.
 
     """
-    DASH_ADDRESSING = enum.auto()
+    NONE = 0
     PLUS_ADDRESSING = enum.auto()
     LOCAL_PART_AS_HOSTNAME = enum.auto()
     STRIP_PERIODS = enum.auto()
@@ -55,7 +55,10 @@ class Rackspace(MailboxProvider):
 
 
 class Yahoo(MailboxProvider):
-    Flags: Rules = Rules.DASH_ADDRESSING
+    # No normalization rules — Yahoo disposable addresses use the format
+    # nickname-keyword@, where the nickname alone is not a deliverable
+    # address. See https://help.yahoo.com/kb/SLN28815.html
+    Flags: Rules = Rules.NONE
     MXDomains: typing.Set[str] = {'yahoodns.net'}
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -111,7 +111,7 @@ class MailboxProviderTestCase(TestCase):
         address = '{}@{}'.format(local_part, domain_part)
         mx_records = [(1, 'mta5.am0.yahoodns.net')]
         self._perform_test(
-            address, '{}@{}'.format(local_part.split('-', 1)[0], domain_part),
+            address, '{}@{}'.format(local_part, domain_part),
             mx_records, 'Yahoo')
 
     def test_yandex(self):


### PR DESCRIPTION
Yahoo dash addresses (e.g. nickname-keyword@) are distinct accounts, not aliases of the base address (nickname@). The DASH_ADDRESSING rule was incorrectly normalizing them as equivalent, causing unrelated addresses to be treated as the same. Base addresses themselves are not deliverable inboxes.

This change removes all normalization rules from the Yahoo provider. The provider class remains to continue identifying Yahoo addresses and to explicitly denote that they are not to be normalized.

Some info on this https://help.yahoo.com/kb/SLN28815.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Change**
  * Dash-based email normalization removed — addresses with dashes (e.g., Yahoo) now preserve the full local-part instead of being truncated.
* **Chores**
  * CI now runs on pull request events in addition to push, respecting existing path filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->