### PR TITLE
Only strip periods for consumer Gmail, not Google Workspace domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ custom domains.
 |------------|:---------------:|:-------------:|:----------------------:|
 | Apple      | x               |               |                        |
 | Fastmail   | x               |               | x                      |
-| Google     | x               | x             |                        |
+| Google     | x               | x*            |                        |
 | Microsoft  | x               |               |                        |
 | ProtonMail | x               |               |                        |
 | Rackspace  | x               |               |                        |
@@ -78,6 +78,11 @@ custom domains.
 - **Plus Addressing**: Strips everything after `+` in the local part
 - **Strip Periods**: Removes `.` from the local part
 - **Local Part as Hostname**: Extracts the subdomain as the local part (Fastmail custom domains)
+
+\* Google strips periods only for consumer Gmail addresses (`gmail.com` and
+`googlemail.com`). Google Workspace custom domains route through the same MX
+servers but treat periods as significant, so periods are preserved for them
+(plus addressing is still stripped).
 
 ## Documentation
 

--- a/email_normalize/__init__.py
+++ b/email_normalize/__init__.py
@@ -178,7 +178,10 @@ class Normalizer:
                 local_part, domain_part = self._local_part_as_hostname(
                     local_part, domain_part
                 )
-            if provider.Flags & providers.Rules.STRIP_PERIODS:
+            if provider.Flags & providers.Rules.STRIP_PERIODS and (
+                not provider.StripPeriodDomains
+                or domain_part in provider.StripPeriodDomains
+            ):
                 local_part = local_part.replace('.', '')
             if provider.Flags & providers.Rules.PLUS_ADDRESSING:
                 local_part = local_part.split('+')[0]

--- a/email_normalize/providers.py
+++ b/email_normalize/providers.py
@@ -24,6 +24,13 @@ class MailboxProvider:
     Flags: typing.ClassVar[Rules]
     MXDomains: typing.ClassVar[frozenset[str]]
 
+    # Domains for which ``Rules.STRIP_PERIODS`` should be applied. Period
+    # stripping is only correct for a provider's consumer domains, not for
+    # custom domains that happen to route mail through the same MX servers
+    # (e.g. Google Workspace). An empty set means period stripping applies
+    # to every domain matched to the provider.
+    StripPeriodDomains: typing.ClassVar[frozenset[str]] = frozenset()
+
 
 class Apple(MailboxProvider):
     Flags = Rules.PLUS_ADDRESSING
@@ -38,6 +45,9 @@ class Fastmail(MailboxProvider):
 class Google(MailboxProvider):
     Flags = Rules.PLUS_ADDRESSING | Rules.STRIP_PERIODS
     MXDomains = frozenset({'google.com', 'googlemail.com'})
+    # Only consumer Gmail strips dots; Google Workspace custom domains do
+    # not. See https://support.google.com/mail/answer/7436150.
+    StripPeriodDomains = frozenset({'gmail.com', 'googlemail.com'})
 
 
 class Microsoft(MailboxProvider):

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -121,14 +121,39 @@ class MailboxProviderTestCase(TestCase):
             'Fastmail',
         )
 
-    def test_google(self):
+    def test_google_consumer_gmail(self):
+        """Consumer Gmail strips periods and plus addressing."""
+        local_part = str(uuid.uuid4()).replace('-', '.')
+        address = f'{local_part}+test@gmail.com'
+        mx_records = [(1, 'aspmx.l.google.com')]
+        self._perform_test(
+            address,
+            f'{local_part.replace(".", "")}@gmail.com',
+            mx_records,
+            'Google',
+        )
+
+    def test_google_consumer_googlemail(self):
+        """Consumer googlemail.com strips periods and plus addressing."""
+        local_part = str(uuid.uuid4()).replace('-', '.')
+        address = f'{local_part}+test@googlemail.com'
+        mx_records = [(1, 'aspmx.l.google.com')]
+        self._perform_test(
+            address,
+            f'{local_part.replace(".", "")}@googlemail.com',
+            mx_records,
+            'Google',
+        )
+
+    def test_google_workspace_preserves_periods(self):
+        """Google Workspace custom domains keep periods but strip plus."""
         local_part = str(uuid.uuid4()).replace('-', '.')
         domain_part = str(uuid.uuid4())
         address = f'{local_part}+test@{domain_part}'
         mx_records = [(1, 'aspmx.l.google.com')]
         self._perform_test(
             address,
-            f'{local_part.replace(".", "")}@{domain_part}',
+            f'{local_part}@{domain_part}',
             mx_records,
             'Google',
         )


### PR DESCRIPTION
Fixes #23.

Period stripping was applied to any domain whose MX records resolve to
Google, but per Google's documentation only consumer Gmail (`gmail.com`,
`googlemail.com`) ignores dots — Workspace custom domains treat them as
significant.

## Changes
- Add a `StripPeriodDomains` class attribute to `MailboxProvider`
  (defaults to empty = applies to all matched domains).
- Set it to `{'gmail.com', 'googlemail.com'}` on `Google`.
- Apply `STRIP_PERIODS` only when the domain is in that set; plus-addressing
  stripping still applies to all Google-hosted domains.
- Update tests and README to document the consumer-vs-Workspace distinction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected email address normalization for Google domains: periods in the local part are now preserved for Google Workspace custom domains while being stripped only for consumer Gmail addresses (gmail.com, googlemail.com).

* **Documentation**
  * Updated normalization rules to reflect corrected Google domain behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->